### PR TITLE
Fix readme, method requires table

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ Update your Feline config to use the Catppuccin components:
 ```lua
 local ctp_feline = require('catppuccin.groups.integrations.feline')
 
-ctp_feline.setup()
+ctp_feline.setup({})
 
 require("feline").setup({
     components = ctp_feline.get(),


### PR DESCRIPTION
Dont know where this was introduced, but the setup method for feline requires a table. An empty table doesnt give the error.

```
E5113: Error while calling lua chunk: vim/shared.lua:0: after the second argument: expected table, got nil
stack traceback:
        [C]: in function 'error'
        vim/shared.lua: in function 'validate'
        vim/shared.lua: in function 'tbl_deep_extend'
        ...catppuccin/lua/catppuccin/groups/integrations/feline.lua:76: in function 'setup'
        /home/alexanderfast/.dotfiles/nvim/init.lua:592: in main chunk
```